### PR TITLE
Moves DismissKeyboard closer to FormGroups in Tutotrial

### DIFF
--- a/client-app/src/markers/SubmissionTutorialModal/Steps/DescriptionStepContent.tsx
+++ b/client-app/src/markers/SubmissionTutorialModal/Steps/DescriptionStepContent.tsx
@@ -1,3 +1,4 @@
+import { DismissKeyboard } from "components";
 import MarkerForm from "markers/MarkerForm";
 import React from "react";
 import { Text, View } from "react-native";
@@ -9,15 +10,17 @@ export default function DescriptionStepContent({
   setMarker,
 }: StepContentProps) {
   return marker ? (
-    <View style={{ maxHeight: 500, backgroundColor: colors.lightBackground }}>
-      <Text style={{ fontSize: 20 }}>
-        Enter the name and description as they appear on the marker.
-      </Text>
-      <Text style={{ fontSize: 16, paddingTop: 10 }}>
-        When you're done, hit Review, to finish up your submission.
-      </Text>
-      <MarkerForm marker={marker} setMarker={setMarker} />
-    </View>
+    <DismissKeyboard>
+      <View style={{ maxHeight: 500, backgroundColor: colors.lightBackground }}>
+        <Text style={{ fontSize: 20 }}>
+          Enter the name and description as they appear on the marker.
+        </Text>
+        <Text style={{ fontSize: 16, paddingTop: 10 }}>
+          When you're done, hit Review, to finish up your submission.
+        </Text>
+        <MarkerForm marker={marker} setMarker={setMarker} />
+      </View>
+    </DismissKeyboard>
   ) : (
     <>
       <Text style={{ fontSize: 20 }}>It looks like something went wrong.</Text>

--- a/client-app/src/markers/SubmissionTutorialModal/Steps/index.tsx
+++ b/client-app/src/markers/SubmissionTutorialModal/Steps/index.tsx
@@ -1,5 +1,4 @@
 import steps from "./steps";
 import keys from "./keys";
-import * as stepHelpers from "./helpers";
 
-export { steps as default, keys, stepHelpers };
+export { steps as default, keys };

--- a/client-app/src/markers/SubmissionTutorialModal/SubmissionTutorialModal.tsx
+++ b/client-app/src/markers/SubmissionTutorialModal/SubmissionTutorialModal.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { Modal, Text, View, Button, KeyboardAvoidingView } from "react-native";
-import { Tutorial, DismissKeyboard } from "components";
+import { Tutorial } from "components";
 import { colors } from "utils";
-import steps, { keys, stepHelpers } from "./Steps";
+import steps from "./Steps";
+import * as stepHelpers from "./Steps/helpers";
 import { StepContentProps } from "./Steps/types";
 
 type SubmissionTutorialModalProps = {
@@ -34,21 +35,19 @@ export default function SubmissionTutorialModal({
         <Tutorial>
           <Tutorial.Header text={currentStep.heading} />
           <Tutorial.Content>
-            <DismissKeyboard>
-              <View>
-                <currentStep.Content
-                  requestLocation={requestLocation}
-                  marker={marker}
-                  setMarker={setMarker}
-                  image={image}
-                  setImage={setImage}
-                />
-                <Text style={{ fontSize: 14, paddingTop: 20 }}>
-                  Click Skip to jump to the end and complete the submission
-                  manually.
-                </Text>
-              </View>
-            </DismissKeyboard>
+            <View>
+              <currentStep.Content
+                requestLocation={requestLocation}
+                marker={marker}
+                setMarker={setMarker}
+                image={image}
+                setImage={setImage}
+              />
+              <Text style={{ fontSize: 14, paddingTop: 20 }}>
+                Click Skip to jump to the end and complete the submission
+                manually.
+              </Text>
+            </View>
           </Tutorial.Content>
           <Tutorial.Footer>
             <Button title="Skip" onPress={close} color={colors.accent} />


### PR DESCRIPTION
This moves the DismissKeyboard hack closer to the Inputs it was meant to fix, because it was making buttons un-clickable elsewhere. This means that less of the area will actually dismiss the keyboard, but it still feels usable and this gets the job done.

Also refactored to remove a require cycle in SubmissionTutorialModal

Closes #16 